### PR TITLE
jdk8: use edit-update-site to enable https

### DIFF
--- a/fiji-openjdk-8/Dockerfile
+++ b/fiji-openjdk-8/Dockerfile
@@ -28,6 +28,11 @@ ENV PATH $PATH:/opt/fiji/Fiji.app
 COPY --chown=fiji:fiji entrypoint.sh /opt/fiji
 ENTRYPOINT ["./entrypoint.sh"]
 
+# Update URLs use https
+RUN ./entrypoint.sh --update edit-update-site ImageJ https://update.imagej.net/
+RUN ./entrypoint.sh --update edit-update-site Fiji https://update.fiji.sc/
+RUN ./entrypoint.sh --update edit-update-site Java-8 https://sites.imagej.net/Java-8/
+
 # Run once to create Java preferences.
 COPY --chown=fiji:fiji demo.py /opt/fiji/
 RUN ./entrypoint.sh --headless --ij2 --console --run ./demo.py 'name="test"'


### PR DESCRIPTION
Temporary fix so that the updater will work in the face
of antivirus firewalls and similar.

see: https://gitter.im/imagej/imagej-updater?at=5ce4fe17c6feb0541ec7d840